### PR TITLE
Fix non data-static-forms

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,13 @@ var onRequestGet = async ({
   return new HTMLRewriter().on("form", {
     element(form) {
       const formName = form.getAttribute("data-static-form-name");
-      form.setAttribute("method", "POST");
-      form.removeAttribute("action");
-      form.append(`<input type="hidden" name="static-form-name" value="${formName}" />`, {
-        html: true
-      });
+      if (formName) {
+        form.setAttribute("method", "POST");
+        form.removeAttribute("action");
+        form.append(`<input type="hidden" name="static-form-name" value="${formName}" />`, {
+          html: true
+        });
+      }
     }
   }).transform(response);
 };


### PR DESCRIPTION
I noticed that your custom package changed a form on my page that was not using the data-static-form-name attribute, so it should have been ignored. This simple change fixed the issue for me.

Also, thanks for your version, that actually works, rather than the official package.